### PR TITLE
fix: CVE vulnerability, Jasypt and java21

### DIFF
--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -46,4 +46,5 @@ jobs:
           files: ${{github.workspace}}/src/pci-gateway/target/site/jacoco/jacoco.xml
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -37,7 +37,12 @@ jobs:
       
       # Run tests and generate coverage
       - name: Build and test with coverage
-        run: mvn -B verify -P all --file src/pom.xml
+        run: mvn -B clean verify --file src/pom.xml
+      
+      # List generated files for debugging
+      - name: List coverage report files
+        if: always()
+        run: find ${{github.workspace}}/src -name "jacoco.xml" -type f
       
       # Upload to Codecov
       - name: Upload coverage to Codecov

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -1,49 +1,33 @@
-
-name: Code Coverage
-
+name: Build/Unit Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]
   pull_request:
-   branches: [main]
-    
+    branches: [main]
 jobs:
-  coverage:
-    
-    name: Build, Run Test and upload test coverage
+  spring:
+    name: App Build and Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    
-    steps:
-      
-      # Checkout Project
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+    env:
+      ACTION_DEBUG: true
 
+    steps:   
+      
       # Setup Java Environment
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
         with:
-          distribution: temurin
-          java-version: '21'
-      
-      # Cache maven dependencies
-      - name: Cache Java Dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      
-      
-      # Upload to Codecov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ${{github.workspace}}/src/pci-gateway/target/site/jacoco/jacoco.xml
-          flags: unittests
-          name: codecov-umbrella
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          java-version: 1.8
+          
+          cache: maven
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+     # Run Maven Verify      
+      - name: Build with Maven
+        run: mvn -B install -P all --file src/pom.xml
+
+    #Removed code climate

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -1,5 +1,5 @@
 
-name: Generate/Upload all Coverage Reports
+name: Code Coverage
 
 on:
   push:
@@ -8,39 +8,42 @@ on:
     branches: [main]
     
 jobs:
-  spring-boot:
+  coverage:
     
-    name: Build, Run Test and upload test coverage to code climate
+    name: Build, Run Test and upload test coverage
     runs-on: ubuntu-latest
     
     steps:
       
       # Checkout Project
-      - name: Checkout File Submission Repository
-        uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
       # Setup Java Environment
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: '21'
       
       # Cache maven dependencies
       - name: Cache Java Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       
-      #P Push coverage to code climate
-      - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.4
-        env:
-          CC_TEST_REPORTER_ID: aae899550bdc89de402e537456d007846bda71c64f7300294a61d1a68f6bfc43
-          JACOCO_SOURCE_PATH: "${{github.workspace}}/src/pci-gateway/src/main/java"
+      # Run tests and generate coverage
+      - name: Build and test with coverage
+        run: mvn -B verify -P all --file src/pom.xml
+      
+      # Upload to Codecov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
         with:
-          # The report file must be there, otherwise Code Climate won't find it
-          coverageCommand: mvn -B verify -P all --file src/pom.xml
-          coverageLocations: ${{github.workspace}}/src/pci-gateway/target/site/jacoco/jacoco.xml:jacoco
+          files: ${{github.workspace}}/src/pci-gateway/target/site/jacoco/jacoco.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -12,6 +12,8 @@ jobs:
     
     name: Build, Run Test and upload test coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -1,33 +1,49 @@
-name: Build/Unit Tests
+name: Generate/Upload all Coverage Reports
 permissions:
   contents: read
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+   branches: [main]
+    
 jobs:
-  spring:
-    name: App Build and Test
+  #Temp disable this workflow
+  if: false 
+  spring-boot:
+    
+    name: Build, Run Test and upload test coverage to code climate
     runs-on: ubuntu-latest
-    env:
-      ACTION_DEBUG: true
-
-    steps:   
+    
+    steps:
       
-      # Setup Java Environment
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          
-          cache: maven
-
-      - name: Checkout Repository
+      # Checkout Project
+      - name: Checkout File Submission Repository
         uses: actions/checkout@v6
 
-     # Run Maven Verify      
-      - name: Build with Maven
-        run: mvn -B install -P all --file src/pom.xml
-
-    #Removed code climate
+      # Setup Java Environment
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      
+      # Cache maven dependencies
+      - name: Cache Java Dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      
+      #P Push coverage to code climate
+      - name: Test & publish code coverage
+        uses: paambaati/codeclimate-action@v2.7.4
+        env:
+          CC_TEST_REPORTER_ID: aae899550bdc89de402e537456d007846bda71c64f7300294a61d1a68f6bfc43
+          JACOCO_SOURCE_PATH: "${{github.workspace}}/src/pci-gateway/src/main/java"
+        with:
+          # The report file must be there, otherwise Code Climate won't find it
+          coverageCommand: mvn -B verify -P all --file src/pom.xml
+          coverageLocations: ${{github.workspace}}/src/pci-gateway/target/site/jacoco/jacoco.xml:jacoco

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -35,9 +35,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       
-      # Run tests and generate coverage
-      - name: Build and test with coverage
-        run: mvn -B clean verify -f src/pci-gateway/pom.xml
       
       # Upload to Codecov
       - name: Upload coverage to Codecov

--- a/.github/workflows/code-climate-test-coverage.yaml
+++ b/.github/workflows/code-climate-test-coverage.yaml
@@ -37,12 +37,7 @@ jobs:
       
       # Run tests and generate coverage
       - name: Build and test with coverage
-        run: mvn -B clean verify --file src/pom.xml
-      
-      # List generated files for debugging
-      - name: List coverage report files
-        if: always()
-        run: find ${{github.workspace}}/src -name "jacoco.xml" -type f
+        run: mvn -B clean verify -f src/pci-gateway/pom.xml
       
       # Upload to Codecov
       - name: Upload coverage to Codecov

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,7 +11,14 @@ jobs:
     name: Build docker images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      # Ensure Maven uses Java 21
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
 
       # In this step, this action saves a list of existing images,
       # the cache is created without them in the post run.
@@ -28,16 +35,16 @@ jobs:
       # Build Docker and Run Tests
       - name: Build docker image
         run: |
-          docker-compose build
+          docker compose build
 
       - name: Standup Docker Pods
         env:
           MVN_PROFILE: demo
         run: |
-          docker-compose up -d
+          docker compose up -d
       
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/src/pci-gateway-test-runner/pom.xml
+++ b/src/pci-gateway-test-runner/pom.xml
@@ -39,12 +39,6 @@
 			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
-			<scope>test</scope>
-		</dependency>
 
 		<!-- Temporary work around for broken cucumber library dependency -->
         <dependency>

--- a/src/pci-gateway-test-runner/pom.xml
+++ b/src/pci-gateway-test-runner/pom.xml
@@ -39,6 +39,12 @@
 			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- Temporary work around for broken cucumber library dependency -->
         <dependency>

--- a/src/pci-gateway-test-runner/pom.xml
+++ b/src/pci-gateway-test-runner/pom.xml
@@ -28,10 +28,23 @@
 		<io.cucumber.version>6.9.1</io.cucumber.version>
 		<surefire.version>2.22.2</surefire.version>
 		<compiler.version>3.8.1</compiler.version>
-		<java.version>1.8</java.version>
+		<java.version>21</java.version>
 	</properties>
 
 	<dependencies>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- Temporary work around for broken cucumber library dependency -->
         <dependency>
@@ -103,6 +116,19 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
+					<compilerArgs>
+						<arg>--add-exports</arg>
+						<arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+						<arg>--add-opens</arg>
+						<arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+					</compilerArgs>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/pci-gateway/Dockerfile
+++ b/src/pci-gateway/Dockerfile
@@ -1,7 +1,7 @@
 #############################################################################################
 ###              Stage where Docker is building spring boot app using maven               ###
 #############################################################################################
-FROM maven:3.6.3-jdk-8 as build
+FROM maven:3.9.6-eclipse-temurin-21 as build
 
 WORKDIR /build
 COPY pom.xml .
@@ -15,7 +15,7 @@ RUN mvn package
 #############################################################################################
 ### Stage where Docker is running a java process to run a service built in previous stage ###
 #############################################################################################
-FROM openjdk:8-jdk-slim
+FROM eclipse-temurin:21-jre
 
 COPY --from=build ./build/target/pci-gateway-*.jar /app/service.jar
 

--- a/src/pci-gateway/pom.xml
+++ b/src/pci-gateway/pom.xml
@@ -119,35 +119,29 @@
 
 			<!-- jacoco code coverage -->
 			<plugin>
-				<groupId>
-					org.jacoco
-				</groupId>
-				<artifactId>
-					jacoco-maven-plugin
-				</artifactId>
-				<version>
-					0.8.6
-				</version>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>
-								prepare-agent
-							</goal>
+							<goal>prepare-agent</goal>
 						</goals>
 					</execution>
 					<!-- attached to Maven test phase -->
 					<execution>
-						<id>
-							report
-						</id>
-						<phase>
-							test
-						</phase>
+						<id>report</id>
+						<phase>test</phase>
 						<goals>
-							<goal>
-								report
-							</goal>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<!-- attached to Maven verify phase for CI/CD pipelines -->
+					<execution>
+						<id>report-verify</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/src/pci-gateway/pom.xml
+++ b/src/pci-gateway/pom.xml
@@ -15,8 +15,8 @@
 	<description>PCI Gateway Api</description>
 
 	<properties>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>2020.0.1-SNAPSHOT</spring-cloud.version>
+		<java.version>21</java.version>
+		<spring-cloud.version>2020.0.6</spring-cloud.version>
 		<log4j2.version>2.17.1</log4j2.version>
 	</properties>
 
@@ -35,18 +35,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>5.3.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>5.3.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>5.3.39</version>
 		</dependency>
 
 		<dependency>
@@ -57,7 +46,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.11</version>
+			<version>3.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -68,7 +57,7 @@
 		<dependency>
 			<groupId>com.github.ulisesbocchio</groupId>
 			<artifactId>jasypt-spring-boot</artifactId>
-			<version>2.0.0</version>
+			<version>3.0.5</version>
 		</dependency>
 
 		<dependency>

--- a/src/pci-gateway/pom.xml
+++ b/src/pci-gateway/pom.xml
@@ -76,6 +76,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>5.3.39</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -119,29 +126,35 @@
 
 			<!-- jacoco code coverage -->
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.11</version>
+				<groupId>
+					org.jacoco
+				</groupId>
+				<artifactId>
+					jacoco-maven-plugin
+				</artifactId>
+				<version>
+					0.8.11
+				</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>prepare-agent</goal>
+							<goal>
+								prepare-agent
+							</goal>
 						</goals>
 					</execution>
 					<!-- attached to Maven test phase -->
 					<execution>
-						<id>report</id>
-						<phase>test</phase>
+						<id>
+							report
+						</id>
+						<phase>
+							test
+						</phase>
 						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<!-- attached to Maven verify phase for CI/CD pipelines -->
-					<execution>
-						<id>report-verify</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>report</goal>
+							<goal>
+								report
+							</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -150,20 +163,6 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-repo-milestone</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-	</repositories>
+	<!-- Using released Spring Cloud BOM; no additional snapshot/milestone repos required. -->
 
 </project>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2,17 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
 	<groupId>ca.bc.gov.open.jag</groupId>
-	<artifactId>pci-gateway</artifactId>
+	<artifactId>pci-gateway-parent</artifactId>
 	<version>0.0.3</version>
-	<name>pci-gateway</name>
-	<description>PCI Gateway Api</description>
+	<name>pci-gateway-parent</name>
+	<description>PCI Gateway Parent Aggregator</description>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -22,167 +16,40 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2020.0.6</spring-cloud.version>
-		<log4j2.version>2.17.1</log4j2.version>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
-	<dependencies>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>5.3.39</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.18.0</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.15</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.github.ulisesbocchio</groupId>
-			<artifactId>jasypt-spring-boot</artifactId>
-			<version>3.0.5</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.codehaus.janino</groupId>
-			<artifactId>janino</artifactId>
-			<version>3.1.2</version>
-		</dependency>
-	</dependencies>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-framework-bom</artifactId>
-				<version>5.3.39</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
-	<profiles>
-
-		<profile>
-
-			<id>splunk</id>
-
-			<repositories>
-				<repository>
-					<id>splunk-artifactory</id>
-					<name>Splunk Releases</name>
-					<url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
-				</repository>
-			</repositories>
-
-			<dependencies>
-				<dependency>
-					<groupId>com.splunk.logging</groupId>
-					<artifactId>splunk-library-javalogging</artifactId>
-					<version>1.11.2</version>
-				</dependency>
-			</dependencies>
-
-		</profile>
-
-	</profiles>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<mainClass>ca.bc.gov.open.jag.pcigateway.PciGatewayApplication</mainClass>
-				</configuration>
-
-
-			</plugin>
-
 			<!-- jacoco code coverage -->
 			<plugin>
-				<groupId>
-					org.jacoco
-				</groupId>
-				<artifactId>
-					jacoco-maven-plugin
-				</artifactId>
-				<version>
-					0.8.11
-				</version>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>
-								prepare-agent
-							</goal>
+							<goal>prepare-agent</goal>
 						</goals>
 					</execution>
-					<!-- attached to Maven test phase -->
 					<execution>
-						<id>
-							report
-						</id>
-						<phase>
-							test
-						</phase>
+						<id>report</id>
+						<phase>test</phase>
 						<goals>
-							<goal>
-								report
-							</goal>
+							<goal>report</goal>
 						</goals>
 					</execution>
-					<!-- attached to Maven verify phase for CI/CD pipelines -->
 					<execution>
-						<id>
-							report-verify
-						</id>
-						<phase>
-							verify
-						</phase>
+						<id>report-verify</id>
+						<phase>verify</phase>
 						<goals>
-							<goal>
-								report
-							</goal>
+							<goal>report</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
-	<!-- Using released Spring Cloud BOM; no additional snapshot/milestone repos required. -->
-
 </project>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -13,6 +13,12 @@
 	<version>0.0.3</version>
 	<name>pci-gateway</name>
 	<description>PCI Gateway Api</description>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>pci-gateway</module>
+		<module>pci-gateway-test-runner</module>
+	</modules>
 
 	<properties>
 		<java.version>21</java.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -157,6 +157,20 @@
 							</goal>
 						</goals>
 					</execution>
+					<!-- attached to Maven verify phase for CI/CD pipelines -->
+					<execution>
+						<id>
+							report-verify
+						</id>
+						<phase>
+							verify
+						</phase>
+						<goals>
+							<goal>
+								report
+							</goal>
+						</goals>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1,36 +1,168 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.4.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>ca.bc.gov.open.jag</groupId>
+	<artifactId>pci-gateway</artifactId>
+	<version>0.0.3</version>
+	<name>pci-gateway</name>
+	<description>PCI Gateway Api</description>
 
-    <groupId>ca.bc.gov.open.jag</groupId>
-    <artifactId>jag-pci-gateway</artifactId>
-    <version>0.3.0</version>
+	<properties>
+		<java.version>21</java.version>
+		<spring-cloud.version>2020.0.6</spring-cloud.version>
+		<log4j2.version>2.17.1</log4j2.version>
+	</properties>
 
-    <name>jag-pci-gateway</name>
-    <packaging>pom</packaging>
-    <url>https://github.com/bcgov-c/jag-pci-gateway</url>
+	<dependencies>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <log4j2.version>2.17.1</log4j2.version>
-    </properties>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 
-    <profiles>
-        <profile>
-            <id>all</id>
-            <modules>
-                <module>pci-gateway</module>
-            </modules>
-        </profile>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 
-        <profile>
-            <id>cucumber</id>
-            <modules>
-                <module>pci-gateway-test-runner</module>
-            </modules>
-        </profile>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>5.3.39</version>
+		</dependency>
 
-    </profiles>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.15</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot</artifactId>
+			<version>3.0.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>3.1.2</version>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>5.3.39</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
+
+		<profile>
+
+			<id>splunk</id>
+
+			<repositories>
+				<repository>
+					<id>splunk-artifactory</id>
+					<name>Splunk Releases</name>
+					<url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+				</repository>
+			</repositories>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.splunk.logging</groupId>
+					<artifactId>splunk-library-javalogging</artifactId>
+					<version>1.11.2</version>
+				</dependency>
+			</dependencies>
+
+		</profile>
+
+	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>ca.bc.gov.open.jag.pcigateway.PciGatewayApplication</mainClass>
+				</configuration>
+
+
+			</plugin>
+
+			<!-- jacoco code coverage -->
+			<plugin>
+				<groupId>
+					org.jacoco
+				</groupId>
+				<artifactId>
+					jacoco-maven-plugin
+				</artifactId>
+				<version>
+					0.8.11
+				</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>
+								prepare-agent
+							</goal>
+						</goals>
+					</execution>
+					<!-- attached to Maven test phase -->
+					<execution>
+						<id>
+							report
+						</id>
+						<phase>
+							test
+						</phase>
+						<goals>
+							<goal>
+								report
+							</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
+
+	<!-- Using released Spring Cloud BOM; no additional snapshot/milestone repos required. -->
 
 </project>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2,54 +2,167 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.4.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
 	<groupId>ca.bc.gov.open.jag</groupId>
-	<artifactId>pci-gateway-parent</artifactId>
+	<artifactId>pci-gateway</artifactId>
 	<version>0.0.3</version>
-	<name>pci-gateway-parent</name>
-	<description>PCI Gateway Parent Aggregator</description>
-	<packaging>pom</packaging>
-
-	<modules>
-		<module>pci-gateway</module>
-		<module>pci-gateway-test-runner</module>
-	</modules>
+	<name>pci-gateway</name>
+	<description>PCI Gateway Api</description>
 
 	<properties>
 		<java.version>21</java.version>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spring-cloud.version>2020.0.6</spring-cloud.version>
+		<log4j2.version>2.17.1</log4j2.version>
 	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>5.3.39</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.15</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot</artifactId>
+			<version>3.0.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>3.1.2</version>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>5.3.39</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
+
+		<profile>
+
+			<id>splunk</id>
+
+			<repositories>
+				<repository>
+					<id>splunk-artifactory</id>
+					<name>Splunk Releases</name>
+					<url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+				</repository>
+			</repositories>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.splunk.logging</groupId>
+					<artifactId>splunk-library-javalogging</artifactId>
+					<version>1.11.2</version>
+				</dependency>
+			</dependencies>
+
+		</profile>
+
+	</profiles>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>ca.bc.gov.open.jag.pcigateway.PciGatewayApplication</mainClass>
+				</configuration>
+
+
+			</plugin>
+
 			<!-- jacoco code coverage -->
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.11</version>
+				<groupId>
+					org.jacoco
+				</groupId>
+				<artifactId>
+					jacoco-maven-plugin
+				</artifactId>
+				<version>
+					0.8.11
+				</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>prepare-agent</goal>
+							<goal>
+								prepare-agent
+							</goal>
 						</goals>
 					</execution>
+					<!-- attached to Maven test phase -->
 					<execution>
-						<id>report</id>
-						<phase>test</phase>
+						<id>
+							report
+						</id>
+						<phase>
+							test
+						</phase>
 						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report-verify</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>report</goal>
+							<goal>
+								report
+							</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
+
 		</plugins>
 	</build>
+
+	<!-- Using released Spring Cloud BOM; no additional snapshot/milestone repos required. -->
+
 </project>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fix all dependabot java CVE
- Jasypt upgraded to 3.0.5 to restore compatibility with newer Spring security/authorization changes and avoid encryption startup issues.
- Java target set to 21 (build/runtime) to satisfy platform requirements and allow newer dependency baselines.
- Spring Framework (spring-webmvc) lifted to 5.3.39 to address critical/high CVEs (including Spring4Shell and later traversal issues) while staying on the 5.3 line.
- Apache Commons Lang upgraded to 3.18.0 to fix the uncontrolled recursion CVE.
- Spring Cloud BOM moved to release 2020.0.6 (was snapshot) and snapshot/milestone repositories removed to pull only signed, supported artifacts and eliminate PKIX warnings.

## Why
- Address critical/high vulnerabilities reported by scanning (Spring Framework, Commons Lang) and ensure secure dependency sourcing.
- Align encryption layer (Jasypt) before other fixes so property decryption remains stable.
- Align build/runtime with Java 21 per requirement and to support patched dependency versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested? Locally and integration test CI

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
